### PR TITLE
pass `--enable-source-maps` flag to `task` script `node` command usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "target/index.d.ts",
   "repository": "github:MinaFoundation/mina-fungible-token",
   "scripts": {
-    "task": "node --no-warnings= --loader ts-node/esm",
+    "task": "node --enable-source-maps --no-warnings= --loader ts-node/esm",
     "test": "npm run task -- --test FungibleToken.test.ts",
     "build": "tsc"
   },


### PR DESCRIPTION
Per Gregor's recommendation