### PR TITLE
Enable proofs in tests

### DIFF
--- a/FungibleToken.test.ts
+++ b/FungibleToken.test.ts
@@ -557,6 +557,18 @@ describe("token integration", () => {
         })
       )
     })
+    it("should not allow changing supply using the vanilla admin contract", async () => {
+      const vanillaContract = new FungibleToken(tokenB)
+      const tx = await Mina.transaction({
+        sender: sender,
+        fee: 1e8,
+      }, async () => {
+        await vanillaContract.setSupply(mintAmount)
+      })
+      tx.sign([tokenBAdmin.key])
+      await tx.prove()
+      await rejects(() => tx.send())
+    })
   })
 })
 

--- a/FungibleToken.test.ts
+++ b/FungibleToken.test.ts
@@ -18,7 +18,7 @@ import { TestPublicKey } from "o1js/dist/node/lib/mina/local-blockchain.js"
 import { FungibleToken, FungibleTokenAdmin, FungibleTokenAdminBase } from "./index.js"
 import { newTestPublicKey } from "./test_util.js"
 
-const proofsEnabled = false
+const proofsEnabled = true
 
 const localChain = await Mina.LocalBlockchain({
   proofsEnabled: proofsEnabled,

--- a/FungibleToken.test.ts
+++ b/FungibleToken.test.ts
@@ -39,7 +39,7 @@ describe("token integration", () => {
   let tokenBAdmin: TestPublicKey
   let tokenBAdminContract: TokenAdminB
   let tokenB: TestPublicKey
-  let tokenBContract: FungibleToken
+  let tokenBContract: FungibleTokenB
   let thirdPartyA: TestPublicKey
   let thirdPartyAContract: ThirdParty
   let thirdPartyB: TestPublicKey


### PR DESCRIPTION
This will take longer, but we could miss errors, in particular with the modular admin contract.

This PR does fix an error that was missed with `proofsEnabled=false`: with that option, the tests passed even when we were using inheritance to change the admin contract. But it fails if we enable the proofs.