### PR TITLE
Implement concurrent minting/burning

### DIFF
--- a/FungibleToken.test.ts
+++ b/FungibleToken.test.ts
@@ -587,7 +587,9 @@ describe("token integration", () => {
       )
       FungibleToken.adminContract = FungibleTokenAdmin
     })
-    it("should not mint too many B tokens using the vanilla admin contract", async () => {
+    it("should not mint too many B tokens using the vanilla admin contract", {
+      skip: !proofsEnabled,
+    }, async () => {
       const tx = await Mina.transaction({
         sender: sender,
         fee: 1e8,

--- a/FungibleToken.test.ts
+++ b/FungibleToken.test.ts
@@ -177,6 +177,27 @@ describe("token integration", () => {
       )
     })
 
+    it("calling the reducer should not change the reported circulating supply", async () => {
+      const initialCirculating = (await tokenAContract.getCirculating()).toBigInt()
+
+      const tx = await Mina.transaction({
+        sender: sender,
+        fee: 1e8,
+      }, async () => {
+        await tokenAContract.updateCirculating()
+      })
+
+      tx.sign([sender.key])
+      await tx.prove()
+      await tx.send()
+
+      localChain.incrementGlobalSlot(1)
+      equal(
+        (await tokenAContract.getCirculating()).toBigInt(),
+        initialCirculating,
+      )
+    })
+
     it("should burn tokens for the sender account", async () => {
       const initialBalance = (await tokenAContract.getBalanceOf(sender))
         .toBigInt()

--- a/FungibleToken.test.ts
+++ b/FungibleToken.test.ts
@@ -153,6 +153,7 @@ describe("token integration", () => {
     it("should mint for the sender account", async () => {
       const initialBalance = (await tokenAContract.getBalanceOf(sender))
         .toBigInt()
+      const initialCirculating = (await tokenAContract.getCirculating()).toBigInt()
 
       const tx = await Mina.transaction({
         sender: sender,
@@ -170,11 +171,16 @@ describe("token integration", () => {
         (await tokenAContract.getBalanceOf(sender)).toBigInt(),
         initialBalance + mintAmount.toBigInt(),
       )
+      equal(
+        (await tokenAContract.getCirculating()).toBigInt(),
+        initialCirculating + mintAmount.toBigInt(),
+      )
     })
 
     it("should burn tokens for the sender account", async () => {
       const initialBalance = (await tokenAContract.getBalanceOf(sender))
         .toBigInt()
+      const initialCirculating = (await tokenAContract.getCirculating()).toBigInt()
 
       const tx = await Mina.transaction({
         sender: sender,
@@ -190,6 +196,10 @@ describe("token integration", () => {
       equal(
         (await tokenAContract.getBalanceOf(sender)).toBigInt(),
         initialBalance - burnAmount.toBigInt(),
+      )
+      equal(
+        (await tokenAContract.getCirculating()).toBigInt(),
+        initialCirculating - burnAmount.toBigInt(),
       )
     })
 
@@ -263,6 +273,7 @@ describe("token integration", () => {
         .toBigInt()
       const initialBalanceReceiver = (await tokenAContract.getBalanceOf(receiver))
         .toBigInt()
+      const initialCirculating = (await tokenAContract.getCirculating()).toBigInt()
 
       const tx = await Mina.transaction({
         sender: sender,
@@ -288,6 +299,10 @@ describe("token integration", () => {
         (await tokenAContract.getBalanceOf(receiver)).toBigInt(),
         initialBalanceReceiver + sendAmount.toBigInt(),
       )
+      equal(
+        (await tokenAContract.getCirculating()).toBigInt(),
+        initialCirculating,
+      )
     })
 
     it("should reject a transaction not signed by the token holder", async () => {
@@ -306,6 +321,8 @@ describe("token integration", () => {
         .toBigInt()
       const initialBalanceReceiver = (await tokenAContract.getBalanceOf(receiver))
         .toBigInt()
+      const initialCirculating = (await tokenAContract.getCirculating()).toBigInt()
+
       const updateSend = AccountUpdate.createSigned(
         sender,
         tokenAContract.deriveTokenId(),
@@ -333,6 +350,10 @@ describe("token integration", () => {
       equal(
         (await tokenAContract.getBalanceOf(receiver)).toBigInt(),
         initialBalanceReceiver + sendAmount.toBigInt(),
+      )
+      equal(
+        (await tokenAContract.getCirculating()).toBigInt(),
+        initialCirculating,
       )
     })
 
@@ -384,6 +405,7 @@ describe("token integration", () => {
     it("should deposit from the user to the token account of the third party", async () => {
       const initialBalance = (await tokenAContract.getBalanceOf(sender))
         .toBigInt()
+      const initialCirculating = (await tokenAContract.getCirculating()).toBigInt()
 
       const tokenId = tokenAContract.deriveTokenId()
 
@@ -417,6 +439,10 @@ describe("token integration", () => {
         (await tokenAContract.getBalanceOf(sender)).toBigInt(),
         initialBalance - depositAmount.toBigInt(),
       )
+      equal(
+        (await tokenAContract.getCirculating()).toBigInt(),
+        initialCirculating,
+      )
     })
 
     it("should send tokens from one contract to another", async () => {
@@ -424,6 +450,8 @@ describe("token integration", () => {
         .toBigInt()
       const initialBalance2 = (await tokenAContract.getBalanceOf(thirdPartyB))
         .toBigInt()
+      const initialCirculating = (await tokenAContract.getCirculating()).toBigInt()
+
       const transferAmount = UInt64.from(1)
       const updateWithdraw = await thirdPartyAContract.withdraw(transferAmount)
       const updateDeposit = await thirdPartyBContract.deposit(transferAmount)
@@ -448,6 +476,10 @@ describe("token integration", () => {
       equal(
         (await tokenAContract.getBalanceOf(thirdPartyB)).toBigInt(),
         initialBalance2 + transferAmount.toBigInt(),
+      )
+      equal(
+        (await tokenAContract.getCirculating()).toBigInt(),
+        initialCirculating,
       )
     })
 
@@ -481,6 +513,7 @@ describe("token integration", () => {
       FungibleToken.adminContract = CustomTokenAdmin
       const initialBalance = (await tokenBContract.getBalanceOf(sender))
         .toBigInt()
+      const initialCirculating = (await tokenBContract.getCirculating()).toBigInt()
 
       const tx = await Mina.transaction({
         sender: sender,
@@ -498,6 +531,10 @@ describe("token integration", () => {
         (await tokenBContract.getBalanceOf(sender)).toBigInt(),
         initialBalance + mintAmount.toBigInt(),
       )
+      equal(
+        (await tokenBContract.getCirculating()).toBigInt(),
+        initialCirculating + mintAmount.toBigInt(),
+      )
       FungibleToken.adminContract = FungibleTokenAdmin
     })
 
@@ -506,6 +543,7 @@ describe("token integration", () => {
         .toBigInt()
       const initialBalanceReceiver = (await tokenBContract.getBalanceOf(receiver))
         .toBigInt()
+      const initialCirculating = (await tokenBContract.getCirculating()).toBigInt()
 
       const tx = await Mina.transaction({
         sender: sender,
@@ -530,6 +568,10 @@ describe("token integration", () => {
       equal(
         (await tokenBContract.getBalanceOf(receiver)).toBigInt(),
         initialBalanceReceiver + sendAmount.toBigInt(),
+      )
+      equal(
+        (await tokenBContract.getCirculating()).toBigInt(),
+        initialCirculating,
       )
     })
 

--- a/FungibleToken.test.ts
+++ b/FungibleToken.test.ts
@@ -572,6 +572,7 @@ describe("token integration", () => {
   })
 })
 
+/** This is a faucet style admin contract, where anyone can mint */
 class TokenAdminB extends SmartContract implements FungibleTokenAdminBase {
   @state(PublicKey)
   private adminPublicKey = State<PublicKey>()
@@ -588,7 +589,6 @@ class TokenAdminB extends SmartContract implements FungibleTokenAdminBase {
 
   @method.returns(Bool)
   public async canMint(_accountUpdate: AccountUpdate) {
-    this.ensureAdminSignature()
     return Bool(true)
   }
 

--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -92,7 +92,7 @@ export class FungibleToken extends TokenContract implements FungibleTokenLike {
   async burn(from: PublicKey, amount: UInt64) {
     const accountUpdate = this.internal.burn({ address: from, amount })
     this.emitEvent("Burn", new BurnEvent({ from, amount }))
-    this.reducer.dispatch(Int64.minusOne.mul(Int64.fromUnsigned(amount)))
+    this.reducer.dispatch(Int64.fromUnsigned(amount).neg())
     return accountUpdate
   }
 
@@ -128,7 +128,7 @@ export class FungibleToken extends TokenContract implements FungibleTokenLike {
         return circulating.add(action)
       },
       Int64.from(oldCirculating),
-      { maxUpdatesWithActions: 10 },
+      { maxUpdatesWithActions: 500 },
     )
     newCirculating.isPositive().assertTrue()
     return newCirculating.magnitude

--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -2,8 +2,11 @@ import {
   AccountUpdate,
   AccountUpdateForest,
   DeployArgs,
+  Field,
+  Int64,
   method,
   PublicKey,
+  Reducer,
   State,
   state,
   Struct,
@@ -29,6 +32,8 @@ export class FungibleToken extends TokenContract implements FungibleTokenLike {
   admin = State<PublicKey>()
   @state(UInt64)
   private circulating = State<UInt64>()
+  @state(Field)
+  actionState = State<Field>()
 
   // This defines the type of the contract that is used to control access to administrative actions.
   // If you want to have a custom contract, overwrite this by setting FungibleToken.adminContract to
@@ -42,6 +47,10 @@ export class FungibleToken extends TokenContract implements FungibleTokenLike {
     Transfer: TransferEvent,
   }
 
+  // We use actions and reducers for changing the circulating supply. That is to allow multiple mints/burns in a single block, which would not work if those would alter the contract state directly.
+  // Minting will emit an action with a positive number corresponding to the amount of tokens minted, burning will emit a negative value.
+  reducer = Reducer({ actionType: Int64 })
+
   async deploy(props: FungibleTokenDeployProps) {
     await super.deploy(props)
 
@@ -50,6 +59,8 @@ export class FungibleToken extends TokenContract implements FungibleTokenLike {
 
     this.account.tokenSymbol.set(props.symbol)
     this.account.zkappUri.set(props.src)
+
+    this.actionState.set(Reducer.initialActionState)
   }
 
   public getAdminContract(): FungibleTokenAdminBase {
@@ -66,23 +77,21 @@ export class FungibleToken extends TokenContract implements FungibleTokenLike {
 
   @method.returns(AccountUpdate)
   async mint(recipient: PublicKey, amount: UInt64) {
-    const circulating = this.circulating.getAndRequireEquals()
-    const nextCirculating = circulating.add(amount)
-    this.circulating.set(nextCirculating)
     const accountUpdate = this.internal.mint({ address: recipient, amount })
     const canMint = await this.getAdminContract()
       .canMint(accountUpdate)
     canMint.assertTrue()
     this.approve(accountUpdate)
     this.emitEvent("Mint", new MintEvent({ recipient, amount }))
+    this.reducer.dispatch(Int64.fromUnsigned(amount))
     return accountUpdate
   }
 
   @method.returns(AccountUpdate)
   async burn(from: PublicKey, amount: UInt64) {
-    this.circulating.set(this.circulating.getAndRequireEquals().sub(amount))
     const accountUpdate = this.internal.burn({ address: from, amount })
     this.emitEvent("Burn", new BurnEvent({ from, amount }))
+    this.reducer.dispatch(Int64.minusOne.mul(Int64.fromUnsigned(amount)))
     return accountUpdate
   }
 
@@ -108,7 +117,21 @@ export class FungibleToken extends TokenContract implements FungibleTokenLike {
 
   @method.returns(UInt64)
   async getCirculating(): Promise<UInt64> {
-    return this.circulating.getAndRequireEquals()
+    let oldCirculating = this.circulating.getAndRequireEquals()
+    let actionState = this.actionState.getAndRequireEquals()
+    let pendingActions = this.reducer.getActions({ fromActionState: actionState })
+
+    let newCirculating: Int64 = this.reducer.reduce(
+      pendingActions,
+      Int64,
+      (circulating: Int64, action: Int64) => {
+        return circulating.add(action)
+      },
+      Int64.from(oldCirculating),
+      { maxUpdatesWithActions: 10 },
+    )
+    newCirculating.isPositive().assertTrue()
+    return newCirculating.magnitude
   }
 
   @method.returns(UInt64)

--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -34,6 +34,11 @@ export class FungibleToken extends TokenContract implements FungibleTokenLike {
   @state(UInt64)
   private circulating = State<UInt64>()
 
+  // This defines the type of the contract that is used to control access to administrative actions.
+  // If you want to have a custom contract, overwrite this by setting FungibleToken.adminContract to
+  // your own implementation of FungibleTokenAdminBase.
+  static adminContract: new(...args: any) => FungibleTokenAdminBase = FungibleTokenAdmin
+
   readonly events = {
     SetAdmin: PublicKey,
     Mint: MintEvent,
@@ -54,7 +59,7 @@ export class FungibleToken extends TokenContract implements FungibleTokenLike {
   }
 
   public getAdminContract(): FungibleTokenAdminBase {
-    return (new FungibleTokenAdmin(this.admin.getAndRequireEquals()))
+    return (new FungibleToken.adminContract(this.admin.getAndRequireEquals()))
   }
 
   @method

--- a/FungibleTokenAdmin.ts
+++ b/FungibleTokenAdmin.ts
@@ -13,7 +13,6 @@ import {
 export type FungibleTokenAdminBase = SmartContract & {
   canMint(accountUpdate: AccountUpdate): Promise<Bool>
   canChangeAdmin(admin: PublicKey): Promise<Bool>
-  canSetSupply(supply: UInt64): Promise<Bool>
 }
 
 export interface FungibleTokenAdminDeployProps extends Exclude<DeployArgs, undefined> {
@@ -50,12 +49,6 @@ export class FungibleTokenAdmin extends SmartContract implements FungibleTokenAd
 
   @method.returns(Bool)
   public async canChangeAdmin(_admin: PublicKey) {
-    this.ensureAdminSignature()
-    return Bool(true)
-  }
-
-  @method.returns(Bool)
-  public async canSetSupply(_supply: UInt64) {
     this.ensureAdminSignature()
     return Bool(true)
   }

--- a/FungibleTokenLike.ts
+++ b/FungibleTokenLike.ts
@@ -4,8 +4,6 @@ import type { AccountUpdate, AccountUpdateForest, AccountUpdateTree, PublicKey, 
 export interface FungibleTokenLike {
   /** Get the balance of the current token for a given public key. */
   getBalanceOf(address: PublicKey): Promise<UInt64>
-  /** Get the maximum supply of the current token. */
-  getSupply(): Promise<UInt64>
   /** Get the amount circulating of the current token. */
   getCirculating(): Promise<UInt64>
   /** Get the number of decimals used in representing the current token. */
@@ -33,11 +31,6 @@ export interface FungibleTokenLike {
    * @param amount the amount of new tokens to create.
    */
   mint(to: PublicKey, amount: UInt64): Promise<AccountUpdate>
-  /**
-   * Set the new supply, effectively changing a possible amount to be minted. Cannot be changed to an amount less than circulating.
-   * @param amount the new supply to set.
-   */
-  setSupply(amount: UInt64): Promise<void>
   /**
    * Approves all account updates in the forest if the sum of total balance change in the account update forest is zero.
    * @param updates the forest containing the account updates.

--- a/examples/concurrent-transfer.eg.ts
+++ b/examples/concurrent-transfer.eg.ts
@@ -95,7 +95,6 @@ const deployTx = await Mina.transaction({
   await adminContract.deploy({ adminPublicKey: admin.publicKey })
   await token.deploy({
     admin: admin.publicKey,
-    supply: UInt64.from(10_000_000_000_000),
     symbol: "abc",
     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts",
   })

--- a/examples/e2e.eg.ts
+++ b/examples/e2e.eg.ts
@@ -27,7 +27,6 @@ const deployTx = await Mina.transaction({
   await adminContract.deploy({ adminPublicKey: admin.publicKey })
   await token.deploy({
     admin: admin.publicKey,
-    supply: UInt64.from(10_000_000_000_000),
     symbol: "abc",
     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts",
   })

--- a/examples/escrow.eg.ts
+++ b/examples/escrow.eg.ts
@@ -81,7 +81,6 @@ const deployTokenTx = await Mina.transaction({
   await adminContract.deploy({ adminPublicKey: admin.publicKey })
   await token.deploy({
     admin: admin.publicKey,
-    supply: UInt64.from(10_000_000_000_000),
     symbol: "abc",
     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/escrow.eg.ts",
   })


### PR DESCRIPTION
In order to do this, we remove the total supply (and the check that the circulating supply does not exceed it) from the main contract, and use actions/reducers to update the circulating supply.

Enforcing a limit on the circulating supply will then be the responsibility of the admin contract.