### PR TITLE
Examples and cleanup

### DIFF
--- a/FungibleToken.test.ts
+++ b/FungibleToken.test.ts
@@ -16,7 +16,6 @@ import {
   UInt64,
   UInt8,
 } from "o1js"
-import { TestPublicKey } from "o1js/dist/node/lib/mina/local-blockchain.js"
 import {
   FungibleToken,
   FungibleTokenAdmin,
@@ -28,50 +27,32 @@ import { newTestPublicKey } from "./test_util.js"
 const proofsEnabled = true
 
 const localChain = await Mina.LocalBlockchain({
-  proofsEnabled: proofsEnabled,
+  proofsEnabled,
   enforceTransactionLimits: false,
 })
 Mina.setActiveInstance(localChain)
 
 describe("token integration", () => {
-  let deployer: TestPublicKey
-  let sender: TestPublicKey
-  let receiver: TestPublicKey
-  let tokenAdmin: TestPublicKey
-  let tokenAdminContract: FungibleTokenAdmin
-  let newTokenAdmin: TestPublicKey
-  let newTokenAdminContract: FungibleTokenAdmin
-  let tokenA: TestPublicKey
-  let tokenAContract: FungibleToken
-  let tokenBAdmin: TestPublicKey
+  let [deployer, sender, receiver] = localChain.testAccounts
+
+  let tokenAdmin = newTestPublicKey()
+  let tokenAdminContract = new FungibleTokenAdmin(tokenAdmin)
+  let newTokenAdmin = newTestPublicKey()
+  let newTokenAdminContract = new FungibleTokenAdmin(newTokenAdmin)
+  let tokenA = newTestPublicKey()
+  let tokenAContract = new FungibleToken(tokenA)
+  let tokenBAdmin = newTestPublicKey()
   let tokenBAdminContract: CustomTokenAdmin
-  let tokenB: TestPublicKey
-  let tokenBContract: FungibleToken
-  let thirdPartyA: TestPublicKey
+  let tokenB = newTestPublicKey()
+  let tokenBContract = new FungibleToken(tokenB)
+  let thirdPartyA = newTestPublicKey()
   let thirdPartyAContract: ThirdParty
-  let thirdPartyB: TestPublicKey
+  let thirdPartyB = newTestPublicKey()
   let thirdPartyBContract: ThirdParty
 
   before(async () => {
-    ;[deployer, sender, receiver] = localChain.testAccounts
-
-    tokenAdmin = newTestPublicKey()
-    tokenAdminContract = new FungibleTokenAdmin(tokenAdmin)
-    newTokenAdmin = newTestPublicKey()
-    newTokenAdminContract = new FungibleTokenAdmin(newTokenAdmin)
-
-    tokenA = newTestPublicKey()
-    tokenAContract = new FungibleToken(tokenA)
-
-    tokenBAdmin = newTestPublicKey()
     tokenBAdminContract = new CustomTokenAdmin(tokenBAdmin)
-    tokenB = newTestPublicKey()
-    tokenBContract = new FungibleToken(tokenB)
-
-    thirdPartyA = newTestPublicKey()
     thirdPartyAContract = new ThirdParty(thirdPartyA)
-
-    thirdPartyB = newTestPublicKey()
     thirdPartyBContract = new ThirdParty(thirdPartyB)
 
     if (proofsEnabled) {

--- a/examples/airdrop.eg.ts
+++ b/examples/airdrop.eg.ts
@@ -1,0 +1,52 @@
+/**
+ * Example implementation of a token airdrop that allows concurrent withdrawals.
+ */
+import { Experimental, Field, method, Poseidon, PublicKey, SmartContract, State, state } from "o1js"
+import { newTestPublicKeys } from "test_util"
+
+class MerkleMap extends Experimental.IndexedMerkleMap(10) {}
+
+// a couple of test accounts
+const accounts = newTestPublicKeys(20)
+
+// create a map of eligible accounts
+const eligible = createEligibleMap(accounts)
+
+/**
+ * Contract that manages airdrop claims.
+ */
+class Airdrop extends SmartContract {
+  @state(Field)
+  eligibleRoot = State(eligible.root)
+
+  @method
+  async claim() {
+  }
+}
+
+/**
+ * Helper function to create a map of eligible accounts.
+ */
+function createEligibleMap(accounts: PublicKey[]) {
+  // predefined MerkleMap of eligible accounts
+  const eligible = new MerkleMap()
+
+  // every account gets 100 tokens
+  accounts.forEach((account) => eligible.insert(key(account), 100n))
+
+  return eligible
+}
+
+/**
+ * How to map an address to a map key.
+ */
+function key(address: PublicKey) {
+  return Poseidon.hashPacked(PublicKey, address)
+}
+
+/**
+ * Mock for fetching the (partial) Merkle Map from a service endpoint.
+ */
+async function fetchEligibleMap() {
+  return eligible
+}

--- a/examples/airdrop.eg.ts
+++ b/examples/airdrop.eg.ts
@@ -1,8 +1,25 @@
 /**
  * Example implementation of a token airdrop that allows concurrent withdrawals.
  */
-import { Experimental, Field, method, Poseidon, PublicKey, SmartContract, State, state } from "o1js"
+import {
+  AccountUpdate,
+  AccountUpdateForest,
+  AccountUpdateTree,
+  Experimental,
+  Field,
+  method,
+  Poseidon,
+  Provable,
+  PublicKey,
+  Reducer,
+  SmartContract,
+  State,
+  state,
+  Struct,
+  UInt64,
+} from "o1js"
 import { newTestPublicKeys } from "test_util"
+import { token, tokenId } from "./token.eg"
 
 class MerkleMap extends Experimental.IndexedMerkleMap(10) {}
 
@@ -13,14 +30,77 @@ const accounts = newTestPublicKeys(20)
 const eligible = createEligibleMap(accounts)
 
 /**
+ * An action to claim your airdrop.
+ */
+class Claim extends Struct({ account: PublicKey, amount: UInt64 }) {}
+
+/**
  * Contract that manages airdrop claims.
  */
 class Airdrop extends SmartContract {
   @state(Field)
   eligibleRoot = State(eligible.root)
 
+  @state(Field)
+  actionState = State(Reducer.initialActionState)
+
+  reducer = Reducer({ actionType: Claim })
+
   @method
-  async claim() {
+  async claim(amount: UInt64) {
+    let account = this.sender.getUnconstrained()
+
+    // ensure that the token account already exists and that the sender knows its private key
+    AccountUpdate.createSigned(account)
+
+    this.reducer.dispatch(new Claim({ account, amount }))
+  }
+
+  @method
+  async settleClaims() {
+    // fetch merkle map and assert that it matches the onchain root
+    let root = this.eligibleRoot.getAndRequireEquals()
+    let eligible = await Provable.witnessAsync(MerkleMap.provable, fetchEligibleMap)
+    eligible.root.assertEquals(root)
+
+    // process claims by reducing actions
+    let actionState = this.actionState.getAndRequireEquals()
+    let actions = this.reducer.getActions({ fromActionState: actionState })
+    let accountUpdates = AccountUpdateForest.empty()
+
+    eligible = this.reducer.reduce(
+      actions,
+      // in every step, we update the eligible map
+      MerkleMap.provable,
+      (eligible, claim) => {
+        // check whether the claim is valid = exactly contained in the map
+        let accountKey = key(claim.account)
+        let amountOption = eligible.getOption(accountKey)
+        let amount = UInt64.Unsafe.fromField(amountOption.orElse(0n))
+        let isValid = amountOption.isSome.and(amount.equals(claim.amount))
+
+        // if the claim is valid, set the amount in the map to zero
+        // (otherwise, set the 0 key to zero, which doesn't change the map)
+        let keyOrDummy = Provable.if(isValid, accountKey, Field(0n))
+        eligible.set(keyOrDummy, 0n)
+
+        // if the claim is valid, add a token account update to our forest of approved updates
+        let update = AccountUpdate.defaultAccountUpdate(claim.account, tokenId)
+        update.balance.addInPlace(amount)
+        this.balance.subInPlace(amount) // this is 0 if the claim is invalid
+        accountUpdates.pushIf(isValid, AccountUpdateTree.from(update))
+
+        return eligible
+      },
+      eligible,
+    )
+
+    // approve the created account updates
+    token.approveBase(accountUpdates)
+
+    // update the onchain root and action state pointer
+    this.eligibleRoot.set(eligible.root)
+    this.actionState.set(actions.hash)
   }
 }
 

--- a/examples/airdrop.eg.ts
+++ b/examples/airdrop.eg.ts
@@ -70,12 +70,12 @@ class Airdrop extends SmartContract {
     let accountUpdates = AccountUpdateForest.empty()
 
     // process claims by reducing actions
-    batchReducer.processNextBatch(proof, (claim) => {
+    batchReducer.processNextBatch(proof, (claim, isDummy) => {
       // check whether the claim is valid = exactly contained in the map
       let accountKey = key(claim.account)
       let amountOption = eligible.getOption(accountKey)
       let amount = UInt64.Unsafe.fromField(amountOption.orElse(0n)) // not unsafe, because only uint64s can be claimed
-      let isValid = amountOption.isSome.and(amount.equals(claim.amount))
+      let isValid = amountOption.isSome.and(amount.equals(claim.amount)).and(isDummy.not())
 
       // if the claim is valid, set the amount in the map to zero
       eligible.setIf(isValid, accountKey, 0n)

--- a/examples/concurrent-transfer.eg.ts
+++ b/examples/concurrent-transfer.eg.ts
@@ -79,40 +79,40 @@ const token = new FungibleToken(contract.publicKey)
 const adminContract = new FungibleTokenAdmin(admin.publicKey)
 let nonce = await getInferredNonce(feepayer.publicKey.toBase58())
 
-// console.log("Deploying token contract.")
-// const deployTx = await Mina.transaction({
-//   sender: feepayer.publicKey,
-//   fee,
-//   nonce,
-// }, async () => {
-//   AccountUpdate.fundNewAccount(feepayer.publicKey, 2)
-//   await adminContract.deploy({ adminPublicKey: admin.publicKey })
-//   await token.deploy({
-//     admin: admin.publicKey,
-//     symbol: "abc",
-//     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts",
-//     decimals: UInt8.from(9),
-//   })
-// })
-// await deployTx.prove()
-// deployTx.sign([feepayer.privateKey, contract.privateKey, admin.privateKey])
-// const deployTxResult = await deployTx.send().then((v) => v.wait())
-// console.log("Deploy tx:", deployTxResult.hash)
+console.log("Deploying token contract.")
+const deployTx = await Mina.transaction({
+  sender: feepayer.publicKey,
+  fee,
+  nonce,
+}, async () => {
+  AccountUpdate.fundNewAccount(feepayer.publicKey, 2)
+  await adminContract.deploy({ adminPublicKey: admin.publicKey })
+  await token.deploy({
+    admin: admin.publicKey,
+    symbol: "abc",
+    src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts",
+    decimals: UInt8.from(9),
+  })
+})
+await deployTx.prove()
+deployTx.sign([feepayer.privateKey, contract.privateKey, admin.privateKey])
+const deployTxResult = await deployTx.send().then((v) => v.wait())
+console.log("Deploy tx:", deployTxResult.hash)
 
-// console.log("Minting new tokens to Alexa.")
-// await fetchAccount({ publicKey: admin.publicKey }) // hack to ensure the admin account is fetched
-// const mintTx = await Mina.transaction({
-//   sender: feepayer.publicKey,
-//   fee,
-// }, async () => {
-//   AccountUpdate.fundNewAccount(feepayer.publicKey, 1)
-//   await token.mint(alexa.publicKey, new UInt64(100e9))
-// })
-// await mintTx.prove()
-// mintTx.sign([feepayer.privateKey, admin.privateKey])
-// const mintTxResult = await mintTx.send()
-// console.log("Mint tx:", mintTxResult.hash)
-// await mintTxResult.wait()
+console.log("Minting new tokens to Alexa.")
+await fetchAccount({ publicKey: admin.publicKey }) // hack to ensure the admin account is fetched
+const mintTx = await Mina.transaction({
+  sender: feepayer.publicKey,
+  fee,
+}, async () => {
+  AccountUpdate.fundNewAccount(feepayer.publicKey, 1)
+  await token.mint(alexa.publicKey, new UInt64(100e9))
+})
+await mintTx.prove()
+mintTx.sign([feepayer.privateKey, admin.privateKey])
+const mintTxResult = await mintTx.send()
+console.log("Mint tx:", mintTxResult.hash)
+await mintTxResult.wait()
 
 console.log("[1] Transferring tokens from Alexa to Billy")
 const transferTx1 = await Mina.transaction({

--- a/examples/concurrent-transfer.eg.ts
+++ b/examples/concurrent-transfer.eg.ts
@@ -71,14 +71,7 @@ const [contract, feepayer, alexa, billy, jackie, admin] = [
   keypair("EKEfnNMvDXL8NMNoWb2rJZdocwNHfh1RbbxWF3RuinFX242rGXxa"),
 ]
 
-console.log(`
-alexa ${alexa.publicKey.toBase58()} ${alexa.privateKey.toBase58()} 
-billy ${billy.publicKey.toBase58()} ${billy.privateKey.toBase58()} 
-jackie ${jackie.publicKey.toBase58()}
-contract ${contract.publicKey.toBase58()}
-admin ${admin.publicKey.toBase58()}
-feepayer ${feepayer.publicKey.toBase58()}
-`)
+printKeypairs({ alexa, billy, jackie, contract, admin, feepayer })
 
 await FungibleToken.compile()
 await FungibleTokenAdmin.compile()
@@ -86,40 +79,40 @@ const token = new FungibleToken(contract.publicKey)
 const adminContract = new FungibleTokenAdmin(admin.publicKey)
 let nonce = await getInferredNonce(feepayer.publicKey.toBase58())
 
-console.log("Deploying token contract.")
-const deployTx = await Mina.transaction({
-  sender: feepayer.publicKey,
-  fee,
-  nonce,
-}, async () => {
-  AccountUpdate.fundNewAccount(feepayer.publicKey, 2)
-  await adminContract.deploy({ adminPublicKey: admin.publicKey })
-  await token.deploy({
-    admin: admin.publicKey,
-    symbol: "abc",
-    src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts",
-    decimals: UInt8.from(9),
-  })
-})
-await deployTx.prove()
-deployTx.sign([feepayer.privateKey, contract.privateKey, admin.privateKey])
-const deployTxResult = await deployTx.send().then((v) => v.wait())
-console.log("Deploy tx:", deployTxResult.hash)
+// console.log("Deploying token contract.")
+// const deployTx = await Mina.transaction({
+//   sender: feepayer.publicKey,
+//   fee,
+//   nonce,
+// }, async () => {
+//   AccountUpdate.fundNewAccount(feepayer.publicKey, 2)
+//   await adminContract.deploy({ adminPublicKey: admin.publicKey })
+//   await token.deploy({
+//     admin: admin.publicKey,
+//     symbol: "abc",
+//     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts",
+//     decimals: UInt8.from(9),
+//   })
+// })
+// await deployTx.prove()
+// deployTx.sign([feepayer.privateKey, contract.privateKey, admin.privateKey])
+// const deployTxResult = await deployTx.send().then((v) => v.wait())
+// console.log("Deploy tx:", deployTxResult.hash)
 
-console.log("Minting new tokens to Alexa.")
-await fetchAccount({ publicKey: admin.publicKey }) // hack to ensure the admin account is fetched
-const mintTx = await Mina.transaction({
-  sender: feepayer.publicKey,
-  fee,
-}, async () => {
-  AccountUpdate.fundNewAccount(feepayer.publicKey, 1)
-  await token.mint(alexa.publicKey, new UInt64(100e9))
-})
-await mintTx.prove()
-mintTx.sign([feepayer.privateKey, admin.privateKey])
-const mintTxResult = await mintTx.send()
-console.log("Mint tx:", mintTxResult.hash)
-await mintTxResult.wait()
+// console.log("Minting new tokens to Alexa.")
+// await fetchAccount({ publicKey: admin.publicKey }) // hack to ensure the admin account is fetched
+// const mintTx = await Mina.transaction({
+//   sender: feepayer.publicKey,
+//   fee,
+// }, async () => {
+//   AccountUpdate.fundNewAccount(feepayer.publicKey, 1)
+//   await token.mint(alexa.publicKey, new UInt64(100e9))
+// })
+// await mintTx.prove()
+// mintTx.sign([feepayer.privateKey, admin.privateKey])
+// const mintTxResult = await mintTx.send()
+// console.log("Mint tx:", mintTxResult.hash)
+// await mintTxResult.wait()
 
 console.log("[1] Transferring tokens from Alexa to Billy")
 const transferTx1 = await Mina.transaction({
@@ -147,4 +140,10 @@ function keypair(base58Key?: string): KeyPair {
   base58Key ??= PrivateKey.random().toBase58()
   let privateKey = PrivateKey.fromBase58(base58Key)
   return { publicKey: privateKey.toPublicKey(), privateKey }
+}
+
+function printKeypairs(keypairs: Record<string, KeyPair>) {
+  for (let [name, keypair] of Object.entries(keypairs)) {
+    console.log(`${name} ${keypair.publicKey.toBase58()} ${keypair.privateKey.toBase58()}`)
+  }
 }

--- a/examples/concurrent-transfer.eg.ts
+++ b/examples/concurrent-transfer.eg.ts
@@ -1,4 +1,4 @@
-import { AccountUpdate, Mina, PrivateKey, PublicKey, UInt64, UInt8 } from "o1js"
+import { AccountUpdate, fetchAccount, Mina, PrivateKey, PublicKey, UInt64, UInt8 } from "o1js"
 import { FungibleToken, FungibleTokenAdmin } from "../index.js"
 
 const url = "https://proxy.devnet.minaexplorer.com/graphql"
@@ -60,23 +60,24 @@ Mina.setActiveInstance(Mina.Network(url))
 
 const feePayerKey = PrivateKey.fromBase58("EKE5nJtRFYVWqrCfdpqJqKKdt2Sskf5Co2q8CWJKEGSg71ZXzES7")
 const [contract, feepayer, alexa, billy, jackie, admin] = [
-  PrivateKey.randomKeypair(),
+  keypair("EKF5VLgGNU9Y3xA1q5mudiiwp47m7RZ8DGhU6JVg6e3fZdejUY5X"),
   {
     privateKey: feePayerKey,
     publicKey: feePayerKey.toPublicKey(),
   },
-  PrivateKey.randomKeypair(),
-  PrivateKey.randomKeypair(),
-  PrivateKey.randomKeypair(),
-  PrivateKey.randomKeypair(),
+  keypair("EKFQXBdCLBGQd1BPmvq9FTLdDEQtpMLUH2SdaAW6yyoDGQbStwPd"),
+  keypair("EKE8H3cNvgHAUQxRa2kxRQ5HqGYWaH5MCyBoAKXsWYVRiDhYNoB4"),
+  keypair("EKF4exFf35LpqPyom9ms35rv1xh7cUTugcXcdpwKd9LSvY9kYzrZ"),
+  keypair("EKEfnNMvDXL8NMNoWb2rJZdocwNHfh1RbbxWF3RuinFX242rGXxa"),
 ]
 
 console.log(`
-alexa ${alexa.privateKey.toBase58()} ${alexa.publicKey.toBase58()}
-billy ${billy.privateKey.toBase58()} ${billy.publicKey.toBase58()}
+alexa ${alexa.publicKey.toBase58()} ${alexa.privateKey.toBase58()} 
+billy ${billy.publicKey.toBase58()} ${billy.privateKey.toBase58()} 
 jackie ${jackie.publicKey.toBase58()}
 contract ${contract.publicKey.toBase58()}
 admin ${admin.publicKey.toBase58()}
+feepayer ${feepayer.publicKey.toBase58()}
 `)
 
 await FungibleToken.compile()
@@ -106,6 +107,7 @@ const deployTxResult = await deployTx.send().then((v) => v.wait())
 console.log("Deploy tx:", deployTxResult.hash)
 
 console.log("Minting new tokens to Alexa.")
+await fetchAccount({ publicKey: admin.publicKey }) // hack to ensure the admin account is fetched
 const mintTx = await Mina.transaction({
   sender: feepayer.publicKey,
   fee,
@@ -114,7 +116,7 @@ const mintTx = await Mina.transaction({
   await token.mint(alexa.publicKey, new UInt64(100e9))
 })
 await mintTx.prove()
-mintTx.sign([feepayer.privateKey])
+mintTx.sign([feepayer.privateKey, admin.privateKey])
 const mintTxResult = await mintTx.send()
 console.log("Mint tx:", mintTxResult.hash)
 await mintTxResult.wait()
@@ -140,3 +142,9 @@ await sendNoWait(feepayer, alexa, jackie.publicKey, 1e9, false)
 await sendNoWait(feepayer, billy, jackie.publicKey, 1e9, false)
 await sendNoWait(feepayer, alexa, jackie.publicKey, 1e9, false)
 await sendNoWait(feepayer, billy, jackie.publicKey, 1e9, false)
+
+function keypair(base58Key?: string): KeyPair {
+  base58Key ??= PrivateKey.random().toBase58()
+  let privateKey = PrivateKey.fromBase58(base58Key)
+  return { publicKey: privateKey.toPublicKey(), privateKey }
+}

--- a/examples/concurrent-transfer.eg.ts
+++ b/examples/concurrent-transfer.eg.ts
@@ -1,4 +1,4 @@
-import { AccountUpdate, Mina, PrivateKey, PublicKey, TokenId, UInt64, UInt8 } from "o1js"
+import { AccountUpdate, Mina, PrivateKey, PublicKey, UInt64, UInt8 } from "o1js"
 import { FungibleToken, FungibleTokenAdmin } from "../index.js"
 
 const url = "https://proxy.devnet.minaexplorer.com/graphql"

--- a/examples/e2e.eg.ts
+++ b/examples/e2e.eg.ts
@@ -1,7 +1,6 @@
 import { equal } from "node:assert"
 import { AccountUpdate, Mina, PrivateKey, UInt64, UInt8 } from "o1js"
 import { FungibleToken, FungibleTokenAdmin } from "../index.js"
-import { TestPublicKeys } from "../test_util.js"
 
 const localChain = await Mina.LocalBlockchain({
   proofsEnabled: false,
@@ -11,7 +10,7 @@ Mina.setActiveInstance(localChain)
 
 const fee = 1e8
 
-const [deployer, owner, alexa, billy] = localChain.testAccounts as TestPublicKeys
+const [deployer, owner, alexa, billy] = localChain.testAccounts
 const contract = PrivateKey.randomKeypair()
 const admin = PrivateKey.randomKeypair()
 

--- a/examples/escrow.eg.ts
+++ b/examples/escrow.eg.ts
@@ -12,7 +12,6 @@ import {
   UInt64,
   UInt8,
 } from "o1js"
-import { TestPublicKeys } from "test_util.js"
 import { FungibleToken, FungibleTokenAdmin } from "../index.js"
 
 export class TokenEscrow extends SmartContract {
@@ -54,7 +53,7 @@ Mina.setActiveInstance(localChain)
 
 const fee = 1e8
 
-const [deployer, owner, alexa, billy, jackie] = localChain.testAccounts as TestPublicKeys
+const [deployer, owner, alexa, billy, jackie] = localChain.testAccounts
 const tokenContract = PrivateKey.randomKeypair()
 const escrowContract = PrivateKey.randomKeypair()
 const admin = PrivateKey.randomKeypair()

--- a/examples/token.eg.ts
+++ b/examples/token.eg.ts
@@ -1,0 +1,11 @@
+/**
+ * This file contains parameters for an example token
+ */
+import { FungibleToken } from "FungibleToken.js"
+import { newTestPublicKey } from "../test_util.js"
+
+export { token, tokenAccount, tokenId }
+
+let tokenAccount = newTestPublicKey()
+let token = new FungibleToken(tokenAccount)
+let tokenId = token.deriveTokenId()

--- a/test_util.ts
+++ b/test_util.ts
@@ -9,3 +9,14 @@ export function newTestPublicKey(): Mina.TestPublicKey {
   pubKey.key = keyPair.privateKey
   return pubKey
 }
+
+export function newTestPublicKeys<N extends number>(n: N): ArrayOfLength<Mina.TestPublicKey, 10> {
+  return Array.from({ length: n }, () => newTestPublicKey()) as ArrayOfLength<
+    Mina.TestPublicKey,
+    10
+  >
+}
+
+type ArrayOfLength<T, L extends number, A extends T[] = []> = number extends L ? T[]
+  : L extends A["length"] ? A
+  : ArrayOfLength<T, L, [...A, T]>

--- a/test_util.ts
+++ b/test_util.ts
@@ -1,5 +1,6 @@
 import { PrivateKey, PublicKey } from "o1js"
-import { TestPublicKey } from "o1js/dist/node/lib/mina/local-blockchain"
+
+type TestPublicKey = PublicKey & { key: PrivateKey }
 
 /** Creates a {@link TestPublicKey} that does not have an account on the chain yet.
  * This is used for non-min accounts

--- a/test_util.ts
+++ b/test_util.ts
@@ -10,10 +10,10 @@ export function newTestPublicKey(): Mina.TestPublicKey {
   return pubKey
 }
 
-export function newTestPublicKeys<N extends number>(n: N): ArrayOfLength<Mina.TestPublicKey, 10> {
+export function newTestPublicKeys<N extends number>(n: N): ArrayOfLength<Mina.TestPublicKey, N> {
   return Array.from({ length: n }, () => newTestPublicKey()) as ArrayOfLength<
     Mina.TestPublicKey,
-    10
+    N
   >
 }
 

--- a/test_util.ts
+++ b/test_util.ts
@@ -1,19 +1,11 @@
-import { PrivateKey, PublicKey } from "o1js"
-
-type TestPublicKey = PublicKey & { key: PrivateKey }
+import { Mina, PrivateKey } from "o1js"
 
 /** Creates a {@link TestPublicKey} that does not have an account on the chain yet.
  * This is used for non-min accounts
  */
-export function newTestPublicKey(): TestPublicKey {
+export function newTestPublicKey(): Mina.TestPublicKey {
   const keyPair = PrivateKey.randomKeypair()
-  let pubKey = keyPair.publicKey as TestPublicKey
+  let pubKey = keyPair.publicKey as Mina.TestPublicKey
   pubKey.key = keyPair.privateKey
   return pubKey
 }
-
-export type TestPublicKeys = ArrayOfLength<TestPublicKey, 10>
-
-type ArrayOfLength<T, L extends number, A extends T[] = []> = number extends L ? T[]
-  : L extends A["length"] ? A
-  : ArrayOfLength<T, L, [...A, T]>


### PR DESCRIPTION
- some cleanup in test
- remove unnecessary test public key types
- revert test util change
- start to write airdrop ex
- finish naive token airdrop example
- fix to au creation, simplifications
- fixup
- refactor to batch reducer
- minor cleanup
- fixup
- fix concurrent transfer test up to mint()
- simplify logging
- revert comment
