### PR TITLE
Fix concurrent transfer better

### DIFF
--- a/examples/concurrent-transfer.eg.ts
+++ b/examples/concurrent-transfer.eg.ts
@@ -1,4 +1,4 @@
-import { AccountUpdate, fetchAccount, Mina, PrivateKey, PublicKey, UInt64, UInt8 } from "o1js"
+import { AccountUpdate, Mina, PrivateKey, PublicKey, UInt64, UInt8 } from "o1js"
 import { FungibleToken, FungibleTokenAdmin } from "../index.js"
 
 const url = "https://proxy.devnet.minaexplorer.com/graphql"
@@ -100,7 +100,6 @@ const deployTxResult = await deployTx.send().then((v) => v.wait())
 console.log("Deploy tx:", deployTxResult.hash)
 
 console.log("Minting new tokens to Alexa.")
-await fetchAccount({ publicKey: admin.publicKey }) // hack to ensure the admin account is fetched
 const mintTx = await Mina.transaction({
   sender: feepayer.publicKey,
   fee,


### PR DESCRIPTION
on top of #60, this is a more fundamental way of fixing the interaction with our token contracts

closes #56

**the issue**
with `state.get()` or `state.getAndRequireEquals()`, we were using o1js' lazy fetch mechanism which was a workaround for the fact that circuits could not be async. in the present case, the lazy fetch mechanism was broken, because the account to be fetched is only known after another account was fetched. in tests, this showed up as trying to fetch a dummy public key instead of the actual account, and not having the actual account later on.

**solution**
now that o1js supports async circuits, we no longer have to rely on the workaround. instead, we fetch the current admin public key directly inside a `Provable.witnessAsync()` block, and add a precondition for it using `.requireEquals()`.