### PR TITLE
Change events as per audit.

### DIFF
--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -52,7 +52,7 @@ export class FungibleToken extends TokenContract {
   static adminContract: new(...args: any) => FungibleTokenAdminBase = FungibleTokenAdmin
 
   readonly events = {
-    SetAdmin: PublicKey,
+    SetAdmin: SetAdminEvent,
     Mint: MintEvent,
     Burn: BurnEvent,
     Transfer: TransferEvent,
@@ -92,7 +92,7 @@ export class FungibleToken extends TokenContract {
     const canChangeAdmin = await adminContract.canChangeAdmin(admin)
     canChangeAdmin.assertTrue()
     this.admin.set(admin)
-    this.emitEvent("SetAdmin", admin)
+    this.emitEvent("SetAdmin", new SetAdminEvent({ adminKey: admin }))
   }
 
   @method.returns(AccountUpdate)
@@ -226,6 +226,10 @@ export class FungibleToken extends TokenContract {
     return this.decimals.getAndRequireEquals()
   }
 }
+
+export class SetAdminEvent extends Struct({
+  adminKey: PublicKey,
+}) {}
 
 export class MintEvent extends Struct({
   recipient: PublicKey,

--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -53,6 +53,7 @@ export class FungibleToken extends TokenContract {
 
   readonly events = {
     SetAdmin: SetAdminEvent,
+    Pause: PauseEvent,
     Mint: MintEvent,
     Burn: BurnEvent,
     Transfer: TransferEvent,
@@ -123,6 +124,7 @@ export class FungibleToken extends TokenContract {
     const canPause = await adminContract.canPause()
     canPause.assertTrue()
     this.paused.set(Bool(true))
+    this.emitEvent("Pause", new PauseEvent({ isPaused: Bool(true) }))
   }
 
   @method
@@ -131,6 +133,7 @@ export class FungibleToken extends TokenContract {
     const canResume = await adminContract.canResume()
     canResume.assertTrue()
     this.paused.set(Bool(false))
+    this.emitEvent("Pause", new PauseEvent({ isPaused: Bool(false) }))
   }
 
   @method
@@ -229,6 +232,10 @@ export class FungibleToken extends TokenContract {
 
 export class SetAdminEvent extends Struct({
   adminKey: PublicKey,
+}) {}
+
+export class PauseEvent extends Struct({
+  isPaused: Bool,
 }) {}
 
 export class MintEvent extends Struct({

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -85,11 +85,20 @@ The following events are emitted from `FungibleToken` when appropriate:
 
 ```ts
 events = {
-  SetAdmin: PublicKey,
+  SetAdmin: SetAdminEvent,
+  Pause: PauseEvent,
   Mint: MintEvent,
   Burn: BurnEvent,
   Transfer: TransferEvent,
 }
+
+export class SetAdminEvent extends Struct({
+  adminKey: PublicKey,
+}) {}
+
+export class PauseEvent extends Struct({
+  isPaused: Bool,
+}) {}
 
 class MintEvent extends Struct({
   recipient: PublicKey,


### PR DESCRIPTION
This implements two recommendations from the audit around events:

- wrapping the admin key in an event type when changing the admin key
- adding an event to indicate changes of the paused status.