### PR TITLE
Pause tokens by default during deployment

### DIFF
--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -32,6 +32,10 @@ interface FungibleTokenDeployProps extends Exclude<DeployArgs, undefined> {
   src: string
   /** Number of decimals in a unit */
   decimals: UInt8
+  /** Unless this is set to `true`, the tokens will start in paused mode,
+   * and will need to be explicitly resumed by calling the `resume()` method.
+   * You should only set this to `true` in atomic deploys. */
+  startUnpaused?: boolean
 }
 
 export class FungibleToken extends TokenContract {
@@ -75,6 +79,11 @@ export class FungibleToken extends TokenContract {
     this.account.zkappUri.set(props.src)
 
     this.actionState.set(Reducer.initialActionState)
+    if (props.startUnpaused) {
+      this.paused.set(Bool(false))
+    } else {
+      this.paused.set(Bool(true))
+    }
   }
 
   public async getAdminContract(): Promise<FungibleTokenAdminBase> {

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -42,6 +42,11 @@ The `deploy` function takes as arguments
 - A string pointing to the source code of the contract -- when following the standard, this should
   point to the source of the standard implementation on github
 - A `UInt8` for the number of decimals
+- An optional `boolean` to signify whether token transfers should be enabled immediately. Unless
+  this is supplied and set to `true`, the token contract will be in a paused state initially, and
+  the `resume()` will need to be called before tokens can be minted or transferred. This is safer if
+  you have a non-atomic deploy (i.e., if you do not have the admin contract deployed in the same
+  transaction as the token contract itself).
 
 and initializes the state of the contract. Initially, the circulating supply is set to zero, as no
 tokens have been created yet.

--- a/examples/concurrent-transfer.eg.ts
+++ b/examples/concurrent-transfer.eg.ts
@@ -92,6 +92,10 @@ const deployTx = await Mina.transaction({
     symbol: "abc",
     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts",
     decimals: UInt8.from(9),
+    // We can set `startUnpaused` to true here, because we are doing an atomic deployment
+    // If you are not deploying the admin and token contracts in the same transaction,
+    // it is safer to start the tokens paused, and resume them only after verifying that
+    // the admin contract has been deployed
     startUnpaused: true,
   })
 })

--- a/examples/concurrent-transfer.eg.ts
+++ b/examples/concurrent-transfer.eg.ts
@@ -92,6 +92,7 @@ const deployTx = await Mina.transaction({
     symbol: "abc",
     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts",
     decimals: UInt8.from(9),
+    startUnpaused: true,
   })
 })
 await deployTx.prove()

--- a/examples/e2e.eg.ts
+++ b/examples/e2e.eg.ts
@@ -29,6 +29,10 @@ const deployTx = await Mina.transaction({
     symbol: "abc",
     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts",
     decimals: UInt8.from(9),
+    // We can set `startUnpaused` to true here, because we are doing an atomic deployment
+    // If you are not deploying the admin and token contracts in the same transaction,
+    // it is safer to start the tokens paused, and resume them only after verifying that
+    // the admin contract has been deployed
     startUnpaused: true,
   })
 })

--- a/examples/e2e.eg.ts
+++ b/examples/e2e.eg.ts
@@ -10,7 +10,7 @@ Mina.setActiveInstance(localChain)
 
 const fee = 1e8
 
-const [deployer, owner, alexa, billy] = Mina.TestPublicKey.random(4)
+const [deployer, owner, alexa, billy] = localChain.testAccounts
 const contract = PrivateKey.randomKeypair()
 const admin = PrivateKey.randomKeypair()
 
@@ -29,6 +29,7 @@ const deployTx = await Mina.transaction({
     symbol: "abc",
     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts",
     decimals: UInt8.from(9),
+    startUnpaused: true,
   })
 })
 await deployTx.prove()

--- a/examples/escrow.eg.ts
+++ b/examples/escrow.eg.ts
@@ -53,7 +53,7 @@ Mina.setActiveInstance(localChain)
 
 const fee = 1e8
 
-const [deployer, owner, alexa, billy, jackie] = Mina.TestPublicKey.random(5)
+const [deployer, owner, alexa, billy, jackie] = localChain.testAccounts
 const tokenContract = PrivateKey.randomKeypair()
 const escrowContract = PrivateKey.randomKeypair()
 const admin = PrivateKey.randomKeypair()
@@ -84,6 +84,7 @@ const deployTokenTx = await Mina.transaction({
     symbol: "abc",
     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/escrow.eg.ts",
     decimals: UInt8.from(9),
+    startUnpaused: true,
   })
 })
 await deployTokenTx.prove()

--- a/examples/escrow.eg.ts
+++ b/examples/escrow.eg.ts
@@ -84,6 +84,10 @@ const deployTokenTx = await Mina.transaction({
     symbol: "abc",
     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/escrow.eg.ts",
     decimals: UInt8.from(9),
+    // We can set `startUnpaused` to true here, because we are doing an atomic deployment
+    // If you are not deploying the admin and token contracts in the same transaction,
+    // it is safer to start the tokens paused, and resume them only after verifying that
+    // the admin contract has been deployed
     startUnpaused: true,
   })
 })


### PR DESCRIPTION
This is safer for non-atomic deploys.