### PR TITLE
Use an account for tracking the total circulation.

### DIFF
--- a/FungibleToken.test.ts
+++ b/FungibleToken.test.ts
@@ -64,7 +64,7 @@ describe("token integration", async () => {
         sender: deployer,
         fee: 1e8,
       }, async () => {
-        AccountUpdate.fundNewAccount(deployer, 2)
+        AccountUpdate.fundNewAccount(deployer, 3)
         await tokenAdminContract.deploy({
           adminPublicKey: tokenAdmin,
         })
@@ -74,6 +74,7 @@ describe("token integration", async () => {
           src: "",
           decimals: UInt8.from(9),
         })
+        await tokenAContract.initialize()
       })
 
       tx.sign([
@@ -91,7 +92,7 @@ describe("token integration", async () => {
         sender: deployer,
         fee: 1e8,
       }, async () => {
-        AccountUpdate.fundNewAccount(deployer, 2)
+        AccountUpdate.fundNewAccount(deployer, 3)
         await tokenBAdminContract.deploy({
           adminPublicKey: tokenBAdmin,
         })
@@ -102,6 +103,7 @@ describe("token integration", async () => {
           decimals: UInt8.from(9),
           startUnpaused: true,
         })
+        await tokenBContract.initialize()
       })
 
       tx.sign([deployer.key, tokenB.key, tokenBAdmin.key])
@@ -177,27 +179,6 @@ describe("token integration", async () => {
       equal(
         (await tokenAContract.getCirculating()).toBigInt(),
         initialCirculating + mintAmount.toBigInt(),
-      )
-    })
-
-    it("calling the reducer should not change the reported circulating supply", async () => {
-      const initialCirculating = (await tokenAContract.getCirculating()).toBigInt()
-
-      const tx = await Mina.transaction({
-        sender: sender,
-        fee: 1e8,
-      }, async () => {
-        await tokenAContract.updateCirculating()
-      })
-
-      tx.sign([sender.key])
-      await tx.prove()
-      await tx.send()
-
-      localChain.incrementGlobalSlot(1)
-      equal(
-        (await tokenAContract.getCirculating()).toBigInt(),
-        initialCirculating,
       )
     })
 
@@ -462,6 +443,8 @@ describe("token integration", async () => {
         })
       )
     })
+
+    it.todo("Should prevent transfers from account that's tracking circulation")
   })
 
   describe("pausing/resuming", () => {

--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -43,8 +43,6 @@ export class FungibleToken extends TokenContract {
   decimals = State<UInt8>()
   @state(PublicKey)
   admin = State<PublicKey>()
-  @state(Field)
-  actionState = State<Field>()
   @state(Bool)
   paused = State<Bool>()
 
@@ -71,7 +69,6 @@ export class FungibleToken extends TokenContract {
     this.account.tokenSymbol.set(props.symbol)
     this.account.zkappUri.set(props.src)
 
-    this.actionState.set(Reducer.initialActionState)
     if (props.startUnpaused) {
       this.paused.set(Bool(false))
     } else {

--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -11,7 +11,6 @@ import {
   Permissions,
   Provable,
   PublicKey,
-  Reducer,
   State,
   state,
   Struct,
@@ -76,7 +75,7 @@ export class FungibleToken extends TokenContract {
     }
   }
 
-  // ** Initialises the account for tracking total circulation. */
+  // ** Initializes the account for tracking total circulation. */
   @method
   async initialize() {
     const accountUpdate = AccountUpdate.createSigned(this.address, this.deriveTokenId())

--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -123,7 +123,7 @@ export class FungibleToken extends TokenContract {
     this.paused.getAndRequireEquals().assertFalse()
     const accountUpdate = this.internal.burn({ address: from, amount })
     const circulationUpdate = AccountUpdate.create(this.address, this.deriveTokenId())
-    circulationUpdate.balanceChange = Int64.fromUnsigned(amount).mul(Int64.minusOne)
+    circulationUpdate.balanceChange = Int64.fromUnsigned(amount).negV2()
     this.emitEvent("Burn", new BurnEvent({ from, amount }))
     return accountUpdate
   }

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -31,7 +31,6 @@ The on-chain state is defined as follows:
 @state(UInt8) decimals = State<UInt8>()
 @state(PublicKey) admin = State<PublicKey>()
 @state(UInt64) private circulating = State<UInt64>()
-@state(Field) actionState = State<Field>()
 @state(Bool) paused = State<Bool>()
 ```
 
@@ -76,13 +75,17 @@ regular users
 @method async resume()
 ```
 
-### Minting, burning, and updating the circulating supply
+### Minting, burning, and keeping track of the circulating supply
 
-In order to allow multiple minting/burning transactions in a single block, we use the
-actions/reducer model of MINA. The `mint` and `burn` methods will modify the token balance in the
-specified account. But instead of directly modifying the value of `circulating` in the contract
-state, they will instead dispatches an action that instructs the reducer to modify the state. The
-method `calculateCirculating` collects all the actions and updates the state of the contract.
+In order to allow multiple minting/burning transactions in a single block, we do not tally the
+circulating supply as part of the contract state. Instead, we use a special account, the balance of
+which always corresponds to the total number of tokens in other accounts. The balance of this
+account is updated in the `mint()` and `burn()` methods. Transfers to and from this account are not
+possible. The `getCirculating()` method reports the balance of the account.
+
+Note that if you want to require certain limits on the circulation, you should express your
+constraints using `requireBetween()` rather than `requireEquals()`. This is more robust against
+minting or burning transactions in the same block invalidating your preconditions.
 
 ## Events
 

--- a/documentation/deploy.md
+++ b/documentation/deploy.md
@@ -1,16 +1,47 @@
 # Deploy
 
-To create a new token, deploy the `FungibleToken` contract. You will need an admin account as well,
-to control permissions. You can either use the supplied contract `FungibleTokenAdmin`, or write your
-own contract that implements `FungibleTokenAdminBase`. An example can be found in
-`FungibleToken.test.ts`, where a non-standard admin contract is implemented (`CustomTokenAdmin`,
-implementing a minting policy that resembles a faucet).
+Setting up a new fungible token requires three steps: deploying an admin contract, deploying the
+token contract itself, and initializing the contract
 
-[!NOTE] Note that you have to write the admin contract from scratch. Inheriting from
-`FungibleTokenAdmin` and overwriting specific methods might not work.
+## Deploying an admin contract
+
+The admin contract handles permissions for privileged actions, such as minting. It is called by the
+token contract whenever a user tries to do a privileged action.
+
+The benefit of separating those permissions out into a separate contract is that it allows changing
+the permission logic without changing the original token contract. That is important because third
+parties that want to integrate a specific token will need the contract code for that token. If most
+tokens use the standard token contract, and only modify the admin contract, the integration burden
+for third parties is reduced significantly.
+
+If you want to change your admin contract, you can write a contract that `extends SmartContract` and
+`implements FungibleTokenAdminBase`.
+
+[!NOTE] Note that if you want to use a custom admin contract, you should write the admin contract
+from scratch. Inheriting from `FungibleTokenAdmin` and overwriting specific methods might not work.
+You can find an example of a custom admin contract in `FungibleToken.test.ts`.
+
+## Deploying the token contract
+
+The `deploy` function of `FungibleToken` takes as one argument the address of the admin contract. If
+you have written your own admin contract, you will also need to set `FungibleToken.adminContract` to
+that class.
 
 [!NOTE] If you do not use the `FungibleToken` as is, third parties that want to integrate your token
 will need to use your custom contract as well.
+
+## Initializing the token contract
+
+After being deployed, the token contract needs to be initialized, by calling the `initialize()`
+method. That method creates an account on the chain that will be used to track the current
+circulation of the token.
+
+[!NOTE] All three steps above can be carried out in a single transaction, or in separate
+transactions. [!NOTE] Each of the three steps requires funding a new account on the chain via
+`AccountUpdate.fundNewAccount`. [!NOTE] Per default, the token contract will start in paused mode.
+If you perform all the steps in one single transaction, you can instead opt for starting it in
+non-paused mode. Otherwise, you will need to call `resume()` before any tokens can be minted or
+transferred.
 
 Refer to
 [examples/e2e.eg.ts](https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts)

--- a/documentation/introduction.md
+++ b/documentation/introduction.md
@@ -26,7 +26,7 @@ const deployTx = await Mina.transaction({
   sender: deployer,
   fee,
 }, async () => {
-  AccountUpdate.fundNewAccount(deployer, 2)
+  AccountUpdate.fundNewAccount(deployer, 3)
   await adminContract.deploy({ adminPublicKey: admin.publicKey })
   await token.deploy({
     admin: admin.publicKey,
@@ -34,6 +34,7 @@ const deployTx = await Mina.transaction({
     src: "https://github.com/MinaFoundation/mina-fungible-token/blob/main/examples/e2e.eg.ts",
     decimals: UInt8.from(9),
   })
+  await tokenBContract.initialize()
 })
 await deployTx.prove()
 deployTx.sign([deployer.key, contract.privateKey, admin.privateKey])

--- a/examples/concurrent-transfer.eg.ts
+++ b/examples/concurrent-transfer.eg.ts
@@ -85,7 +85,7 @@ const deployTx = await Mina.transaction({
   fee,
   nonce,
 }, async () => {
-  AccountUpdate.fundNewAccount(feepayer.publicKey, 2)
+  AccountUpdate.fundNewAccount(feepayer.publicKey, 3)
   await adminContract.deploy({ adminPublicKey: admin.publicKey })
   await token.deploy({
     admin: admin.publicKey,
@@ -98,6 +98,7 @@ const deployTx = await Mina.transaction({
     // the admin contract has been deployed
     startUnpaused: true,
   })
+  await token.initialize()
 })
 await deployTx.prove()
 deployTx.sign([feepayer.privateKey, contract.privateKey, admin.privateKey])

--- a/examples/e2e.eg.ts
+++ b/examples/e2e.eg.ts
@@ -22,7 +22,7 @@ const deployTx = await Mina.transaction({
   sender: deployer,
   fee,
 }, async () => {
-  AccountUpdate.fundNewAccount(deployer, 2)
+  AccountUpdate.fundNewAccount(deployer, 3)
   await adminContract.deploy({ adminPublicKey: admin.publicKey })
   await token.deploy({
     admin: admin.publicKey,
@@ -35,6 +35,7 @@ const deployTx = await Mina.transaction({
     // the admin contract has been deployed
     startUnpaused: true,
   })
+  await token.initialize()
 })
 await deployTx.prove()
 deployTx.sign([deployer.key, contract.privateKey, admin.privateKey])

--- a/examples/escrow.eg.ts
+++ b/examples/escrow.eg.ts
@@ -77,7 +77,7 @@ const deployTokenTx = await Mina.transaction({
   sender: deployer,
   fee,
 }, async () => {
-  AccountUpdate.fundNewAccount(deployer, 2)
+  AccountUpdate.fundNewAccount(deployer, 3)
   await adminContract.deploy({ adminPublicKey: admin.publicKey })
   await token.deploy({
     admin: admin.publicKey,
@@ -90,6 +90,7 @@ const deployTokenTx = await Mina.transaction({
     // the admin contract has been deployed
     startUnpaused: true,
   })
+  await token.initialize()
 })
 await deployTokenTx.prove()
 deployTokenTx.sign([deployer.key, tokenContract.privateKey, admin.privateKey])


### PR DESCRIPTION
Instead of using actions and reducers to update the current circulation in the contract state, we now use an account where the balance corresponds to the current circulation.

- We use an account with the key of the token contract.
- The account balance is updated at every call of `mint()` and `burn()`.
- The `approveBase()` method checks that none of the involved `AccountUpdate`s does involve this
- special account.