### PR TITLE
Add a check for circulating supply address to `transfer()`

### DIFF
--- a/FungibleToken.test.ts
+++ b/FungibleToken.test.ts
@@ -428,39 +428,35 @@ describe("token integration", async () => {
     })
 
     it("Should prevent transfers from account that's tracking circulation", async () => {
-      const tx = await Mina.transaction({
-        sender: sender,
-        fee: 1e8,
-      }, async () => {
-        AccountUpdate.fundNewAccount(sender, 1)
-        await tokenAContract.transfer(
-          tokenA,
-          receiver,
-          sendAmount,
-        )
-      })
-
-      tx.sign([sender.key])
-      await tx.prove()
-      await rejects(() => tx.send())
+      await rejects(() =>
+        Mina.transaction({
+          sender: sender,
+          fee: 1e8,
+        }, async () => {
+          AccountUpdate.fundNewAccount(sender, 1)
+          await tokenAContract.transfer(
+            tokenA,
+            receiver,
+            sendAmount,
+          )
+        })
+      )
     })
 
     it("Should prevent transfers to account that's tracking circulation", async () => {
-      const tx = await Mina.transaction({
-        sender: sender,
-        fee: 1e8,
-      }, async () => {
-        AccountUpdate.fundNewAccount(sender, 1)
-        await tokenAContract.transfer(
-          sender,
-          tokenA,
-          sendAmount,
-        )
-      })
-
-      tx.sign([sender.key])
-      await tx.prove()
-      await rejects(() => tx.send())
+      await rejects(() =>
+        Mina.transaction({
+          sender: sender,
+          fee: 1e8,
+        }, async () => {
+          AccountUpdate.fundNewAccount(sender, 1)
+          await tokenAContract.transfer(
+            sender,
+            tokenA,
+            sendAmount,
+          )
+        })
+      )
     })
 
     it("Should reject manually constructed transfers from the account that's tracking circulation", async () => {

--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -121,6 +121,9 @@ export class FungibleToken extends TokenContractV2 {
     const adminContract = await this.getAdminContract()
     const canMint = await adminContract.canMint(accountUpdate)
     canMint.assertTrue(FungibleTokenErrors.noPermissionToMint)
+    recipient.equals(this.address).assertFalse(
+      FungibleTokenErrors.noTransferFromCirculation,
+    )
     this.approve(accountUpdate)
     this.emitEvent("Mint", new MintEvent({ recipient, amount }))
     const circulationUpdate = AccountUpdate.create(this.address, this.deriveTokenId())
@@ -133,6 +136,9 @@ export class FungibleToken extends TokenContractV2 {
     this.paused.getAndRequireEquals().assertFalse(FungibleTokenErrors.tokenPaused)
     const accountUpdate = this.internal.burn({ address: from, amount })
     const circulationUpdate = AccountUpdate.create(this.address, this.deriveTokenId())
+    from.equals(this.address).assertFalse(
+      FungibleTokenErrors.noTransferFromCirculation,
+    )
     circulationUpdate.balanceChange = Int64.fromUnsigned(amount).negV2()
     this.emitEvent("Burn", new BurnEvent({ from, amount }))
     return accountUpdate

--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -145,6 +145,12 @@ export class FungibleToken extends TokenContractV2 {
   @method
   async transfer(from: PublicKey, to: PublicKey, amount: UInt64) {
     this.paused.getAndRequireEquals().assertFalse()
+    from.equals(this.address).assertFalse(
+      "Can't transfer to/from the circulation account",
+    )
+    to.equals(this.address).assertFalse(
+      "Can't transfer to/from the circulation account",
+    )
     this.internal.send({ from, to, amount })
   }
 


### PR DESCRIPTION
Fixes #94.