### PR TITLE
Expect specific error messages in tests.

### DIFF
--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -38,7 +38,7 @@ export const FungibleTokenErrors = {
   noTransferFromCirculation: "Can't transfer to/from the circulation account",
   noPermissionChangeAllowed: "Can't change permissions for access or receive on token accounts",
   flashMinting:
-    "Flash-minting detected. Please make sure that your `AccountUpdate`s are ordered properly, so that tokens are not received before they are sent.",
+    "Flash-minting or unbalanced transaction detected. Please make sure that your transaction is balanced, and that your `AccountUpdate`s are ordered properly, so that tokens are not received before they are sent.",
   unbalancedTransaction: "Transaction is unbalanced",
 }
 


### PR DESCRIPTION
We had a number of tests which expect transactions to fail. With this commit, we specify the errors that we expect the transactions to fail with, so we know that we are testing what we want to test.

Fixes #95.