### PR TITLE
Set permissions to set permissions on circulation account to impossible

### DIFF
--- a/FungibleToken.ts
+++ b/FungibleToken.ts
@@ -92,6 +92,7 @@ export class FungibleToken extends TokenContractV2 {
     let permissions = Permissions.default()
     // This is necessary in order to allow token holders to burn.
     permissions.send = Permissions.none()
+    permissions.setPermissions = Permissions.impossible()
     accountUpdate.account.permissions.set(permissions)
   }
 


### PR DESCRIPTION
This is a prudent measure to prevent a malicious deployer from changing permissions on the circulation account after deployment. There is no concrete attack vector identified with that, but since there is no valid reason to change the permissions, we might as well explicitly forbid it.