### PR TITLE
Revert unnecessary signature "fix"

### DIFF
--- a/FungibleTokenAdmin.ts
+++ b/FungibleTokenAdmin.ts
@@ -61,9 +61,7 @@ export class FungibleTokenAdmin extends SmartContract implements FungibleTokenAd
       return pk
     })
     this.adminPublicKey.requireEquals(admin)
-    let adminUpdate = AccountUpdate.createSigned(admin)
-    adminUpdate.body.useFullCommitment = Bool(true)
-    return adminUpdate
+    return AccountUpdate.createSigned(admin)
   }
 
   @method.returns(Bool)


### PR DESCRIPTION
this change came from a misunderstanding of the commitment that is signed when _not_ toggling `useFullCommitment`