### PR TITLE
Docs fixes

### DIFF
--- a/documentation/introduction.md
+++ b/documentation/introduction.md
@@ -5,7 +5,7 @@ can be found on [github](https://github.com/MinaFoundation/mina-fungible-token),
 [npm package](https://www.npmjs.com/package/mina-fungible-token).
 
 The fungible token standard uses Mina's native support for custom tokens (see
-[MIP-4](https://github.com/MinaProtocol/MIPs/blob/main/MIPS/mip-0004-zkapps.md)). An
+[MIP-4](https://github.com/MinaProtocol/MIPs/blob/main/MIPS/mip-0004-zkapps.md#token-mechanics)). An
 account on Mina can be created to hold either Mina, or a custom token.
 
 To create a new token, one creates a smart contract, which becomes the owner for the token, and uses

--- a/documentation/introduction.md
+++ b/documentation/introduction.md
@@ -5,7 +5,7 @@ can be found on [github](https://github.com/MinaFoundation/mina-fungible-token),
 [npm package](https://www.npmjs.com/package/mina-fungible-token).
 
 The fungible token standard uses Mina's native support for custom tokens (see
-[MIP-4](https://github.com/MinaProtocol/MIPs/blob/main/MIPS/mip-zkapps.md#token-mechanics)). An
+[MIP-4](https://github.com/MinaProtocol/MIPs/blob/main/MIPS/mip-0004-zkapps.md)). An
 account on Mina can be created to hold either Mina, or a custom token.
 
 To create a new token, one creates a smart contract, which becomes the owner for the token, and uses

--- a/documentation/use_in_zk_app.md
+++ b/documentation/use_in_zk_app.md
@@ -9,20 +9,26 @@ Interacting with tokens from a zkApp is as simple as writing off-chain code (sam
 previous chapter is executed from within zkApp methods):
 
 ```ts
+import {
+    SmartContract, state, State, method, DeployArgs, PublicKey, UInt64
+} from 'o1js';
+
+import { FungibleToken } from 'mina-fungible-token';
+
 export class TokenEscrow extends SmartContract {
   @state(PublicKey)
   tokenAddress = State<PublicKey>()
   @state(UInt64)
   total = State<UInt64>()
 
-  deploy(args: DeployArgs & { tokenAddress: PublicKey }) {
+  async deploy(args: DeployArgs & { tokenAddress: PublicKey }) {
     super.deploy(args)
     this.tokenAddress.set(args.tokenAddress)
     this.total.set(UInt64.zero)
   }
 
   @method
-  deposit(from: PublicKey, amount: UInt64) {
+  async deposit(from: PublicKey, amount: UInt64) {
     const token = new FungibleToken(this.tokenAddress.getAndRequireEquals())
     token.transfer(from, this.address, amount)
     const total = this.total.getAndRequireEquals()
@@ -30,7 +36,7 @@ export class TokenEscrow extends SmartContract {
   }
 
   @method
-  withdraw(to: PublicKey, amount: UInt64) {
+  async withdraw(to: PublicKey, amount: UInt64) {
     const token = new FungibleToken(this.tokenAddress.getAndRequireEquals())
     const total = this.total.getAndRequireEquals()
     total.greaterThanOrEqual(amount)

--- a/documentation/use_in_zk_app.md
+++ b/documentation/use_in_zk_app.md
@@ -9,11 +9,9 @@ Interacting with tokens from a zkApp is as simple as writing off-chain code (sam
 previous chapter is executed from within zkApp methods):
 
 ```ts
-import {
-    SmartContract, state, State, method, DeployArgs, PublicKey, UInt64
-} from 'o1js';
+import { DeployArgs, method, PublicKey, SmartContract, State, state, UInt64 } from "o1js"
 
-import { FungibleToken } from 'mina-fungible-token';
+import { FungibleToken } from "mina-fungible-token"
 
 export class TokenEscrow extends SmartContract {
   @state(PublicKey)


### PR DESCRIPTION
1-) The hyperlink for the "MIP-4" in the introduction is not found, so I updated it to the latest link of the MIP-4.
2-) In the token escrow contract, when I copied and pasted the code, it did not compile because of the fact that "async" keyword was not written for the functions. Also, in order to make the job of the developers easier, I added imports for the script (assuming that the developer installed the mina-fungible-token via npm).